### PR TITLE
feat: aggregated trades SubKind

### DIFF
--- a/barter-data/src/exchange/bybit/channel.rs
+++ b/barter-data/src/exchange/bybit/channel.rs
@@ -1,6 +1,7 @@
 use crate::{
     exchange::bybit::Bybit,
     subscription::{
+        aggregated_trade::PublicAggregatedTrades,
         book::{OrderBooksL1, OrderBooksL2},
         liquidation::Liquidations,
         trade::PublicTrades,
@@ -33,6 +34,14 @@ impl BybitChannel {
 
 impl<Server, Instrument> Identifier<BybitChannel>
     for Subscription<Bybit<Server>, Instrument, PublicTrades>
+{
+    fn id(&self) -> BybitChannel {
+        BybitChannel::TRADES
+    }
+}
+
+impl<Server, Instrument> Identifier<BybitChannel>
+    for Subscription<Bybit<Server>, Instrument, PublicAggregatedTrades>
 {
     fn id(&self) -> BybitChannel {
         BybitChannel::TRADES

--- a/barter-data/src/exchange/bybit/message.rs
+++ b/barter-data/src/exchange/bybit/message.rs
@@ -4,7 +4,7 @@ use crate::{
         bybit::{channel::BybitChannel, subscription::BybitResponse, trade::BybitTrade},
         ExchangeId,
     },
-    subscription::trade::PublicTrade,
+    subscription::{aggregated_trade::PublicAggregatedTrade, trade::PublicTrade},
     Identifier,
 };
 use barter_integration::model::SubscriptionId;
@@ -94,6 +94,19 @@ impl Identifier<Option<SubscriptionId>> for BybitMessage<BybitTrade> {
 
 impl<InstrumentId: Clone> From<(ExchangeId, InstrumentId, BybitMessage<BybitTrade>)>
     for MarketIter<InstrumentId, PublicTrade>
+{
+    fn from(
+        (exchange_id, instrument, message): (ExchangeId, InstrumentId, BybitMessage<BybitTrade>),
+    ) -> Self {
+        match message {
+            BybitMessage::Trade(trade) => Self::from((exchange_id, instrument, trade)),
+            BybitMessage::Response(_) => Self(vec![]),
+        }
+    }
+}
+
+impl<InstrumentId: Clone> From<(ExchangeId, InstrumentId, BybitMessage<BybitTrade>)>
+    for MarketIter<InstrumentId, PublicAggregatedTrade>
 {
     fn from(
         (exchange_id, instrument, message): (ExchangeId, InstrumentId, BybitMessage<BybitTrade>),

--- a/barter-data/src/exchange/bybit/mod.rs
+++ b/barter-data/src/exchange/bybit/mod.rs
@@ -9,7 +9,9 @@ use crate::{
     },
     instrument::InstrumentData,
     subscriber::{validator::WebSocketSubValidator, WebSocketSubscriber},
-    subscription::{book::OrderBooksL1, trade::PublicTrades, Map},
+    subscription::{
+        aggregated_trade::PublicAggregatedTrades, book::OrderBooksL1, trade::PublicTrades, Map,
+    },
     transformer::stateless::StatelessTransformer,
     ExchangeWsStream,
 };
@@ -120,6 +122,21 @@ where
 {
     type Stream = ExchangeWsStream<
         StatelessTransformer<Self, Instrument::Id, PublicTrades, BybitMessage<BybitTrade>>,
+    >;
+}
+
+impl<Instrument, Server> StreamSelector<Instrument, PublicAggregatedTrades> for Bybit<Server>
+where
+    Instrument: InstrumentData,
+    Server: ExchangeServer + Debug + Send + Sync,
+{
+    type Stream = ExchangeWsStream<
+        StatelessTransformer<
+            Self,
+            Instrument::Id,
+            PublicAggregatedTrades,
+            BybitMessage<BybitTrade>,
+        >,
     >;
 }
 

--- a/barter-data/src/exchange/mod.rs
+++ b/barter-data/src/exchange/mod.rs
@@ -235,7 +235,7 @@ impl ExchangeId {
             (
                 BybitPerpetualsUsd,
                 Perpetual,
-                PublicTrades | PublicAggregatedTrades | OrderBooksL1 | Liquidations,
+                PublicTrades | PublicAggregatedTrades | OrderBooksL1 | OrderBooksL2 | Liquidations,
             ) => true,
             (Coinbase, Spot, PublicTrades) => true,
             (GateioSpot, Spot, PublicTrades) => true,
@@ -245,7 +245,11 @@ impl ExchangeId {
             (GateioPerpetualsBtc, Perpetual, PublicTrades) => true,
             (GateioOptions, Option(_), PublicTrades) => true,
             (Kraken, Spot, PublicTrades | OrderBooksL1) => true,
-            (Okx, Spot | Future(_) | Perpetual | Option(_), PublicTrades) => true,
+            (
+                Okx,
+                Spot | Future(_) | Perpetual | Option(_),
+                PublicTrades | PublicAggregatedTrades | OrderBooksL1 | OrderBooksL2,
+            ) => true,
 
             (_, _, _) => false,
         }

--- a/barter-data/src/exchange/mod.rs
+++ b/barter-data/src/exchange/mod.rs
@@ -232,7 +232,11 @@ impl ExchangeId {
             (Bitfinex, Spot, PublicTrades) => true,
             (Bitmex, Perpetual, PublicTrades) => true,
             (BybitSpot, Spot, PublicTrades) => true,
-            (BybitPerpetualsUsd, Perpetual, PublicTrades | OrderBooksL1 | Liquidations) => true,
+            (
+                BybitPerpetualsUsd,
+                Perpetual,
+                PublicTrades | PublicAggregatedTrades | OrderBooksL1 | Liquidations,
+            ) => true,
             (Coinbase, Spot, PublicTrades) => true,
             (GateioSpot, Spot, PublicTrades) => true,
             (GateioFuturesUsd, Future(_), PublicTrades) => true,

--- a/barter-data/src/exchange/okx/channel.rs
+++ b/barter-data/src/exchange/okx/channel.rs
@@ -1,6 +1,7 @@
 use super::Okx;
 use crate::{
     subscription::{
+        aggregated_trade::PublicAggregatedTrades,
         book::{OrderBooksL1, OrderBooksL2},
         trade::PublicTrades,
         Subscription,
@@ -34,6 +35,12 @@ impl OkxChannel {
 }
 
 impl<Instrument> Identifier<OkxChannel> for Subscription<Okx, Instrument, PublicTrades> {
+    fn id(&self) -> OkxChannel {
+        OkxChannel::TRADES
+    }
+}
+
+impl<Instrument> Identifier<OkxChannel> for Subscription<Okx, Instrument, PublicAggregatedTrades> {
     fn id(&self) -> OkxChannel {
         OkxChannel::TRADES
     }

--- a/barter-data/src/exchange/okx/mod.rs
+++ b/barter-data/src/exchange/okx/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     exchange::{Connector, ExchangeId, ExchangeSub, PingInterval, StreamSelector},
     instrument::InstrumentData,
     subscriber::{validator::WebSocketSubValidator, WebSocketSubscriber},
-    subscription::trade::PublicTrades,
+    subscription::{aggregated_trade::PublicAggregatedTrades, trade::PublicTrades},
     transformer::stateless::StatelessTransformer,
 };
 use barter_integration::{
@@ -152,5 +152,16 @@ where
         OkxWebSocketParser,
         WsStream,
         StatelessTransformer<Self, Instrument::Id, PublicTrades, OkxTrades>,
+    >;
+}
+
+impl<Instrument> StreamSelector<Instrument, PublicAggregatedTrades> for Okx
+where
+    Instrument: InstrumentData,
+{
+    type Stream = ExchangeStream<
+        OkxWebSocketParser,
+        WsStream,
+        StatelessTransformer<Self, Instrument::Id, PublicAggregatedTrades, OkxTrades>,
     >;
 }

--- a/barter-data/src/exchange/okx/trade.rs
+++ b/barter-data/src/exchange/okx/trade.rs
@@ -1,7 +1,7 @@
 use crate::{
     event::{MarketEvent, MarketIter},
     exchange::{ExchangeId, ExchangeSub},
-    subscription::trade::PublicTrade,
+    subscription::{aggregated_trade::PublicAggregatedTrade, trade::PublicTrade},
     Identifier,
 };
 use barter_integration::model::{Exchange, Side, SubscriptionId};
@@ -113,6 +113,39 @@ impl<InstrumentId: Clone> From<(ExchangeId, InstrumentId, OkxTrades)>
                 })
             })
             .collect()
+    }
+}
+
+impl<InstrumentId: Clone> From<(ExchangeId, InstrumentId, OkxTrades)>
+    for MarketIter<InstrumentId, PublicAggregatedTrade>
+{
+    fn from((exchange_id, instrument, trades): (ExchangeId, InstrumentId, OkxTrades)) -> Self {
+        let (total_price, total_amount, high, low) = trades.data.iter().fold(
+            (0.0, 0.0, f64::MIN, f64::MAX),
+            |(total_price, total_amount, high, low), trade| {
+                (
+                    total_price + trade.price,
+                    total_amount + trade.amount,
+                    high.max(trade.price),
+                    low.min(trade.price),
+                )
+            },
+        );
+        let time = trades.data[0].time; // All trades will have the same ts
+        let count = trades.data.len();
+
+        Self(vec![Ok(MarketEvent {
+            exchange_time: time,
+            received_time: Utc::now(),
+            exchange: Exchange::from(exchange_id),
+            instrument: instrument.clone(),
+            kind: PublicAggregatedTrade {
+                price: total_price / count as f64,
+                amount: total_amount / count as f64,
+                high,
+                low,
+            },
+        })])
     }
 }
 

--- a/barter-data/src/subscription/aggregated_trade.rs
+++ b/barter-data/src/subscription/aggregated_trade.rs
@@ -1,0 +1,27 @@
+use super::SubscriptionKind;
+use barter_macro::{DeSubKind, SerSubKind};
+use serde::{Deserialize, Serialize};
+
+/// Barter [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields
+/// [`PublicAggregatedTrade`] [`MarketEvent<T>`](crate::event::MarketEvent) events.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, DeSubKind, SerSubKind)]
+pub struct PublicAggregatedTrades;
+
+impl SubscriptionKind for PublicAggregatedTrades {
+    type Event = PublicAggregatedTrade;
+}
+
+/// Normalised Barter [`PublicAggregatedTrade`] model. Works the same as
+/// [`PublicTrade`](crate::subscription::trade::PublicTrade) but aggregates results for the same
+/// timestamp into one [`MarketEvent<T>`](crate::event::MarketEvent) event.
+///
+/// Use case:
+/// - Aggregating Candles
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct PublicAggregatedTrade {
+    pub id: String,
+    pub price: f64,
+    pub amount: f64,
+    pub high: f64,
+    pub low: f64,
+}

--- a/barter-data/src/subscription/aggregated_trade.rs
+++ b/barter-data/src/subscription/aggregated_trade.rs
@@ -17,9 +17,8 @@ impl SubscriptionKind for PublicAggregatedTrades {
 ///
 /// Use case:
 /// - Aggregating Candles
-#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct PublicAggregatedTrade {
-    pub id: String,
     pub price: f64,
     pub amount: f64,
     pub high: f64,

--- a/barter-data/src/subscription/mod.rs
+++ b/barter-data/src/subscription/mod.rs
@@ -32,6 +32,9 @@ pub mod liquidation;
 /// Public trade [`SubscriptionKind`] and the associated Barter output data model.
 pub mod trade;
 
+/// Public aggregated trade [`SubscriptionKind`] and the associated Barter output data model.
+pub mod aggregated_trade;
+
 /// Defines the type of a [`Subscription`], and the output [`Self::Event`] that it yields.
 pub trait SubscriptionKind
 where

--- a/barter-data/src/subscription/mod.rs
+++ b/barter-data/src/subscription/mod.rs
@@ -59,6 +59,7 @@ pub struct Subscription<Exchange = ExchangeId, Inst = Instrument, Kind = SubKind
 )]
 pub enum SubKind {
     PublicTrades,
+    PublicAggregatedTrades,
     OrderBooksL1,
     OrderBooksL2,
     OrderBooksL3,


### PR DESCRIPTION
The purpose of this PR is to create a new SubKind "PublicAggregatedTrades" that is almost identical to PublicTrades except that it aggregates all trades that comes in on the same ts into one aggregated trade with high/low added. This is to make candle aggregation more efficient.